### PR TITLE
Run container as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,8 @@ RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add
   && apt-get install -y google-chrome-stable \
   && rm -rf /var/lib/apt/lists/*
 
-# Skapa användare
-RUN useradd -ms /bin/bash ubuntu
-
 # Skapa loggkatalog
-RUN mkdir -p /var/log/supervisor && chown -R ubuntu:ubuntu /var/log/supervisor
+RUN mkdir -p /var/log/supervisor
 
 # Kopiera supervisor config
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/README.md
+++ b/README.md
@@ -29,6 +29,4 @@ SKA INTE KÖRAS ONLINE! BARA LOKALT! Tailscale är att rekommendera
 📍 Gå till `http://<server-ip>:80`  
 (eller `http://<tailscale-IP>:80` om du kör via Tailscale)
 
-OBS!
-
-Du måste sätta env variabel UBUNTU_PASSWORD med value 'ditt egna lösenord' utan '
+Containern körs som root som standard. Ingen inloggning behövs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - pico_shared:/home/ubuntu/shared
     restart: unless-stopped
     network_mode: host  # Krävs för Tailscale-access till port 80
-    user: "1000:1000"   # Se till att rätt UID kör (undvik root)
 
 volumes:
   pico_shared:


### PR DESCRIPTION
## Summary
- remove explicit user mapping from `docker-compose.yml`
- drop `useradd` step and redundant chown from `Dockerfile`
- clarify in README that the container now runs as root

## Testing
- `docker --version` *(fails: command not found)*
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779a4f73d0832ab6155d9993cbeefe