### PR TITLE
Radera set-password och uppdatera README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ SKA INTE KÖRAS ONLINE! BARA LOKALT! Tailscale är att rekommendera
 ✅ xdotool (för GUI-automation)  
 ✅ cron (för framtida automatisering)  
 ✅ Ingen VNC-lösenkod i webbläsaren (enkel åtkomst)
+✅ Inget lösenord krävs vid start
 
 ---
 
@@ -29,4 +30,4 @@ SKA INTE KÖRAS ONLINE! BARA LOKALT! Tailscale är att rekommendera
 📍 Gå till `http://<server-ip>:80`  
 (eller `http://<tailscale-IP>:80` om du kör via Tailscale)
 
-Containern körs som root som standard. Ingen inloggning behövs.
+Containern körs som root som standard. Ingen inloggning eller lösenord behövs.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,13 +1,3 @@
-[program:set-password]
-command=/bin/bash -c "echo ubuntu:${UBUNTU_PASSWORD} | chpasswd"
-environment=UBUNTU_PASSWORD=%(ENV_UBUNTU_PASSWORD)s
-autostart=true
-startsecs=0
-priority=1
-autorestart=false
-stderr_logfile=/var/log/set-password.err.log
-stdout_logfile=/var/log/set-password.out.log
-
 [supervisord]
 nodaemon=true
 logfile=/var/log/supervisor/supervisord.log


### PR DESCRIPTION
## Sammanfattning
- tog bort blocket `[program:set-password]` ur `supervisord.conf`
- README: la till att inget lösenord krävs och förtydligade åtkomsttexten

## Testing
- `docker-compose config` *(fail: command not found)*
- `apt-get update` *(fail: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68779b073e1c832abe50727a8505f16a