### PR TITLE
Fix noVNC port och förtydliga README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # webtop
-✅ Ubuntu 22.04 ✅ XFCE desktop ✅ x11vnc + noVNC på port 80 ✅ Java (OpenJDK 11) ✅ Google Chrome ✅ xdotool, cron ✅ Supervisor för enkel hantering
+✅ Ubuntu 22.04 ✅ XFCE desktop ✅ x11vnc + noVNC på port 6080 ✅ Java (OpenJDK 11) ✅ Google Chrome ✅ xdotool, cron ✅ Supervisor för enkel hantering
 
 # 🖥️ Pico Webtop
 
 **Pico Webtop** är en lättviktsbaserad Linux-desktop i Docker med noVNC och XFCE4, optimerad för att köra Java-baserade program via webbläsare – t.ex. för att administrera ett passersystem.
 
-Tillgänglig direkt via Tailscale eller LAN på port `80`.
+Tillgänglig direkt via Tailscale eller LAN på port `6080`.
+Öppna webbläsaren och surfa till `http://<server-ip>:6080` för att komma åt noVNC.
 
 SKA INTE KÖRAS ONLINE! BARA LOKALT! Tailscale är att rekommendera
 
@@ -27,7 +28,7 @@ SKA INTE KÖRAS ONLINE! BARA LOKALT! Tailscale är att rekommendera
 
 ## 🌐 Åtkomst
 
-📍 Gå till `http://<server-ip>:80`  
-(eller `http://<tailscale-IP>:80` om du kör via Tailscale)
+📍 Gå till `http://<server-ip>:6080`
+(eller `http://<tailscale-IP>:6080` om du kör via Tailscale)
 
 Containern körs som root som standard. Ingen inloggning eller lösenord behövs.


### PR DESCRIPTION
## Sammanfattning
- rätta portnumret till `6080`
- lägg till instruktion om hur man når noVNC

## Testning
- `docker --version` *(misslyckades: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779e312494832aabce053a2a04285c