### PR TITLE
Use modern keyring method for Chrome install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 # Installera Chrome
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list' \
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing.gpg \
+  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
   && apt-get update \
   && apt-get install -y google-chrome-stable \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- replace deprecated `apt-key add` with `gpg --dearmor`
- store Chrome signing key in `/usr/share/keyrings` and reference it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877a1256488832aac90ec68e3187a14