### PR TITLE
Byt till Chromium och uppdatera README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,8 @@ RUN apt-get update && apt-get install -y \
   gnupg \
   && rm -rf /var/lib/apt/lists/*
 
-# Installera Chrome
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/google-linux-signing.gpg \
-  && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux-signing.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-  && apt-get update \
-  && apt-get install -y google-chrome-stable \
+# Installera Chromium i stället för Google Chrome
+RUN apt-get update && apt-get install -y chromium-browser \
   && rm -rf /var/lib/apt/lists/*
 
 # Skapa loggkatalog

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # webtop
-✅ Ubuntu 22.04 ✅ XFCE desktop ✅ x11vnc + noVNC på port 6080 ✅ Java (OpenJDK 11) ✅ Google Chrome ✅ xdotool, cron ✅ Supervisor för enkel hantering
+✅ Ubuntu 22.04 ✅ XFCE desktop ✅ x11vnc + noVNC på port 6080 ✅ Java (OpenJDK 11) ✅ Chromium ✅ xdotool, cron ✅ Supervisor för enkel hantering
 
 # 🖥️ Pico Webtop
 
@@ -18,7 +18,7 @@ SKA INTE KÖRAS ONLINE! BARA LOKALT! Tailscale är att rekommendera
 ✅ XFCE4 skrivbordsmiljö  
 ✅ x11vnc + noVNC (åtkomst via webbläsare)  
 ✅ Java (OpenJDK 11)  
-✅ Google Chrome  
+✅ Chromium
 ✅ xdotool (för GUI-automation)  
 ✅ cron (för framtida automatisering)  
 ✅ Ingen VNC-lösenkod i webbläsaren (enkel åtkomst)


### PR DESCRIPTION
## Ändringar
- ersatt installation av Google Chrome med `chromium-browser`
- uppdaterat README så att Google Chrome byts ut mot Chromium

## Test
- `docker build -t webtop-test .` _(misslyckas: `docker` saknas)_

------
https://chatgpt.com/codex/tasks/task_e_6877bfe87d90832aba18e17ab55d15ba