### PR TITLE
Replace Google Chrome with Chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,10 @@ RUN apt-get update && apt-get install -y \
   gnupg \
   && rm -rf /var/lib/apt/lists/*
 
-# Installera Google Chrome
-RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-  && apt-get update \
-  && apt-get install -y google-chrome-stable \
-  && rm -rf /var/lib/apt/lists/*
+# Installera Chromium via Snap
+RUN apt-get update && \
+    apt-get install -y snapd && \
+    snap install chromium
 
 # Skapa loggkatalog
 RUN mkdir -p /var/log/supervisor


### PR DESCRIPTION
## Summary
- update Dockerfile to install Chromium via snap

## Testing
- `flake8 src/` *(fails: FileNotFoundError)*
- `mypy src/` *(fails: can't read file 'src')*
- `pytest --cov=src/` *(runs, 0 tests collected)*

Docker is not installed, so the image build and Chromium start could not be verified.

------
https://chatgpt.com/codex/tasks/task_e_6878f125d620832a936c46341917b3c3